### PR TITLE
Add CLI install instructions via uv tool

### DIFF
--- a/for-teams/cli.mdx
+++ b/for-teams/cli.mdx
@@ -10,6 +10,30 @@ import BrowserOnly from "@docusaurus/BrowserOnly";
 
 Transformer Lab can be accessed via CLI using the `lab` executable.
 
+## Install
+
+The CLI is distributed as a Python package and can be installed using [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv tool install transformerlab-cli
+```
+
+This adds a `lab` command to your terminal. To upgrade to the latest version:
+
+```bash
+uv tool install transformerlab-cli --force --reinstall
+```
+
+:::note
+Requires Python 3.10 or higher. If you don't have `uv` installed, you can install it with:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+See the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/) for more options.
+:::
+
 <BrowserOnly>
   {() => <AsciinemaPlayer src={"/img/cli/start.cast"} options={{ speed: 2 }} />}
 </BrowserOnly>


### PR DESCRIPTION
## Summary
- Add install section to the CLI docs page with `uv tool install transformerlab-cli` as the primary install method
- Include upgrade command and uv installation instructions with link to full docs

## Test plan
- [ ] Verify the docs page renders correctly at /for-teams/cli