### PR TITLE
Document transformerlab-cli agent skill

### DIFF
--- a/for-teams/cli.mdx
+++ b/for-teams/cli.mdx
@@ -123,12 +123,15 @@ View or set configuration values.
 # View all configuration values
 lab config
 
+# Get a single configuration value
+lab config get <key>
+
 # Set a configuration value
-lab config <key> <value>
+lab config set <key> <value>
 
 # Examples
-lab config server http://localhost:8000
-lab config current_experiment my_experiment
+lab config set server http://localhost:8000
+lab config set current_experiment my_experiment
 ```
 
 | Argument | Description         |

--- a/for-teams/running-a-task/multi-node-tasks-slurm-skypilot.md
+++ b/for-teams/running-a-task/multi-node-tasks-slurm-skypilot.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Node Tasks
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 This guide explains how multi-node tasks behave when `resources.num_nodes > 1`, and how to write `task.yaml` for SLURM and SkyPilot providers.

--- a/for-teams/running-a-task/task-parameters.md
+++ b/for-teams/running-a-task/task-parameters.md
@@ -1,6 +1,6 @@
 ---
 title: Task Parameters
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 This guide explains how to define and configure task parameters in Transformer Lab. Parameters are used to pass configuration values, hyperparameters, and other settings to your task scripts, which can be accessed via `lab.get_config()`.

--- a/for-teams/running-a-task/task-submission-advanced.md
+++ b/for-teams/running-a-task/task-submission-advanced.md
@@ -1,6 +1,6 @@
 ---
 title: Sweeps
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 Once you are comfortable running single tasks, you can take advantage of **parameterization** and **sweeps** to explore many configurations automatically.

--- a/for-teams/running-a-task/task-submission-agent-skill.md
+++ b/for-teams/running-a-task/task-submission-agent-skill.md
@@ -1,0 +1,66 @@
+---
+title: Task Submission Using AI Agents
+sidebar_position: 5
+---
+
+Transformer Lab ships an [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) that lets Claude Code (or any coding agent that supports skills) drive the `lab` CLI on your behalf. Once installed, you can ask your agent in natural language to create tasks, queue jobs on compute providers, stream logs, and pull down artifacts — without memorizing CLI flags or writing `task.yaml` by hand.
+
+## Prerequisites
+
+- Install the `lab` CLI with [uv](https://docs.astral.sh/uv/):
+
+  ```bash
+  uv tool install transformerlab-cli
+  ```
+
+  See [CLI](/for-teams/cli) for more install options and full command reference.
+
+- [Claude Code](https://docs.claude.com/en/docs/claude-code) (or another agent harness that supports the skills format) is installed.
+
+The agent will walk you through logging in and picking a current experiment the first time it needs them.
+
+## Install the skill
+
+From your project directory, install the skill with:
+
+```bash
+npx skills add transformerlab/transformerlab-app --skill transformerlab-cli
+```
+
+This teaches your agent how to use `lab` to check job status, stream logs, download artifacts, queue tasks, manage providers, and more.
+
+## Example: create and queue a fine-tune from a prompt
+
+With the skill installed, start a Claude Code session and send:
+
+> create a task that finetunes SmolLM2 on a fake dataset using the huggingface library.
+
+Claude will:
+
+- Scaffold a task directory with a `task.yaml` plus a small training script that uses the HuggingFace `transformers` library against a synthetic dataset.
+- Register it in your current experiment by running `lab task add ./<task-dir>`.
+- Report back the new task ID.
+
+Once the task exists, follow up with:
+
+> ok now queue this on our skypilot provider
+
+Claude will call `lab task queue <task-id>`, pick the SkyPilot provider, fill in parameter defaults from `task.yaml`, and hand back the job ID. You can then ask it to tail logs, list artifacts, or download results — all of which map to existing `lab job ...` subcommands.
+
+## What the agent can do
+
+The skill exposes the full `lab` surface area to the agent, including:
+
+- `lab task add` / `task list` / `task info` / `task delete`
+- `lab task queue` (with provider selection and parameter prompting)
+- `lab job list` / `job info` / `job artifacts` / `job download`
+- `lab job monitor` (interactive TUI)
+- `lab config` and `lab status` for inspecting CLI state
+
+Because the agent is just driving the CLI, anything you can do from the terminal is available — the skill primarily teaches the agent *when* and *how* to reach for each command.
+
+## Where to go next
+
+- [Task Submission Using the CLI](task-submission-cli.md) — the underlying commands the agent uses.
+- [Task YAML Structure](task-yaml-structure.md) — so you can review and tweak what the agent generated.
+- [Task Parameters](task-parameters.md) — to understand the parameter schema the agent will fill in when queuing.

--- a/for-teams/running-a-task/task-submission-cli.md
+++ b/for-teams/running-a-task/task-submission-cli.md
@@ -40,7 +40,7 @@ Most CLI commands operate on a “current experiment” value stored in the CLI 
 To set it:
 
 ```bash
-lab config current_experiment my-experiment-name
+lab config set current_experiment my-experiment-name
 ```
 
 To confirm:

--- a/for-teams/running-a-task/task-submission.md
+++ b/for-teams/running-a-task/task-submission.md
@@ -72,7 +72,7 @@ For complete YAML field documentation, see [Task YAML Structure](task-yaml-struc
 
 ## High‑level ways to submit tasks
 
-There are two main ways to submit tasks; they share the same underlying task metadata and providers:
+There are three main ways to submit tasks; they share the same underlying task metadata and providers:
 
 - **GUI (recommended if you prefer a visual workflow)**  
   - In an experiment’s **Tasks** tab, click **New** to open the **Add New Task** dialog.
@@ -111,6 +111,16 @@ There are two main ways to submit tasks; they share the same underlying task met
     - Use the task’s defined parameters to prompt for values (or apply defaults with `--no-interactive`).
     - Send a launch request to the selected compute provider to create a job.
   - See [this link](task-submission-cli.md) for concrete examples.
+
+- **AI Agent (let Claude Code or another coding agent drive the CLI)**
+  - Install the Transformer Lab agent skill so your coding agent knows how to use `lab`:
+
+    ```bash
+    npx skills add transformerlab/transformerlab-app --skill transformerlab-cli
+    ```
+
+  - Then describe what you want in natural language — e.g. _"create a task that finetunes SmolLM2 on a fake dataset using the HuggingFace library"_ followed by _"now queue this on our skypilot provider"_ — and the agent will scaffold the task, register it, and queue it for you.
+  - See [this link](task-submission-agent-skill.md) for the full walkthrough.
 
 
 ## Using your own training scripts inside tasks


### PR DESCRIPTION
## Summary
- New page `for-teams/running-a-task/task-submission-agent-skill.md` covering install (`npx skills add transformerlab/transformerlab-app --skill transformerlab-cli`) and a worked example where Claude creates a SmolLM2 fine-tune task and queues it on SkyPilot.
- `task-submission.md` overview now lists AI Agent as a third submission method alongside GUI and CLI, with sidebar positions bumped so the new page slots in after the CLI page.
- Corrected `lab config` examples in `cli.mdx` and `task-submission-cli.md` — the CLI requires `lab config set <key> <value>` / `lab config get <key>`, not bare `lab config <key> <value>`.

## Test plan
- [ ] \`yarn build\` (or \`yarn start\`) renders without broken links or sidebar regressions
- [ ] New page appears at position 5 under "Running a Task"
- [ ] Links from \`task-submission.md\` to the new page resolve